### PR TITLE
Change to supress warning messages when E_STRICT error reporting enabled on PHP5.

### DIFF
--- a/Google_Spreadsheet.php
+++ b/Google_Spreadsheet.php
@@ -255,7 +255,8 @@ class Google_Spreadsheet
 		{
 			if ($entry->title->text == $ss)
 			{
-				$ss_id = array_pop(explode("/",$entry->id->text));
+				$ss_id_explode = explode("/",$entry->id->text);
+				$ss_id = array_pop($ss_id_explode);
 
 				$this->spreadsheet_id = $ss_id;
 
@@ -286,7 +287,8 @@ class Google_Spreadsheet
 			{
 				if ($entry->title->text == $ws)
 				{
-					$wk_id = array_pop(explode("/",$entry->id->text));
+					$wk_id_explode = explode("/",$entry->id->text);
+					$wk_id = array_pop($wk_id_explode);
 
 					$this->worksheet_id = $wk_id;
 


### PR DESCRIPTION
Function "array_pop()" passes its parameter by reference.  Only
variables should be passed by reference.  Passing a function (i.e.
"explode()") by reference triggers a warning message in PHP5 if you have
E_STRICT error reporting enabled.
