### PR TITLE
(Warning)Only variables should be passed by ref.

### DIFF
--- a/Google_Spreadsheet.php
+++ b/Google_Spreadsheet.php
@@ -255,7 +255,8 @@ class Google_Spreadsheet
 		{
 			if ($entry->title->text == $ss)
 			{
-				$ss_id = array_pop(explode("/",$entry->id->text));
+				$ss_id = explode("/",$entry->id->text);
+				$ss_id = array_pop($ss_id);
 
 				$this->spreadsheet_id = $ss_id;
 
@@ -286,7 +287,8 @@ class Google_Spreadsheet
 			{
 				if ($entry->title->text == $ws)
 				{
-					$wk_id = array_pop(explode("/",$entry->id->text));
+					$wk_id = explode("/",$entry->id->text);
+					$wk_id = array_pop($wk_id);
 
 					$this->worksheet_id = $wk_id;
 


### PR DESCRIPTION
Code is passing the result of the explode(lines 258 & 291) function (a value) into array_pop, but array_pop expects an array variable (by reference), not a value.

We can fix it by using an array variable to store the result of explode, and then passing that into array_pop.

Though Its just a warning, if we can avoid it, better! Cheers!!
